### PR TITLE
Fix impossibility to run this prototype with latest "thread.js" library

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
     "bower_components"
   ],
   "dependencies": {
-    "threads": "gaia-components/threads#master"
+    "threads": "gaia-components/threads#v0.1.2"
   }
 }


### PR DESCRIPTION
When I tried tonight to run this prototype inside a webIDE, he doesn't works.

After look a little, the "threads.js" changes a lot from the last commit.
I fix the version to ensure to have a working version for demonstrations.
